### PR TITLE
propagate error from the streamer

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -157,7 +157,7 @@ func (i *Interceptor) StreamClient() grpc.StreamClientInterceptor {
 		return &monitoredClientStream{ClientStream: client, monitor: monitor, labels: prometheus.Labels{
 			"service": service,
 			"handler": method,
-		}}, nil
+		}}, err
 	}
 }
 


### PR DESCRIPTION
if streamer returned an error client can be nil, StreamClient should
return this error to the caller, so it would know that it shouldn't send
any messages to this stream