### PR TITLE
grpc_client_connections cardinality fix

### DIFF
--- a/v4/metric_client_connections.go
+++ b/v4/metric_client_connections.go
@@ -22,6 +22,9 @@ func NewClientConnectionsStatsHandler(vec *prometheus.GaugeVec) *ClientConnectio
 	return &ClientConnectionsStatsHandler{
 		baseStatsHandler: baseStatsHandler{
 			collector: vec,
+			options: statsHandlerOptions{
+				client: true,
+			},
 		},
 		vec: vec,
 	}

--- a/v4/metric_client_connections_test.go
+++ b/v4/metric_client_connections_test.go
@@ -20,12 +20,12 @@ func TestNewClientConnectionsStatsHandler(t *testing.T) {
 	ctx = h.TagConn(ctx, &stats.ConnTagInfo{
 		LocalAddr: &net.TCPAddr{
 			IP:   net.IPv4(1, 2, 3, 4),
-			Port: 90,
+			Port: 4213412,
 			Zone: "",
 		},
 		RemoteAddr: &net.TCPAddr{
 			IP:   net.IPv4(4, 3, 2, 1),
-			Port: 111,
+			Port: 8080,
 			Zone: "",
 		},
 	})
@@ -35,12 +35,12 @@ func TestNewClientConnectionsStatsHandler(t *testing.T) {
 	ctx = h.TagConn(ctx, &stats.ConnTagInfo{
 		LocalAddr: &net.TCPAddr{
 			IP:   net.IPv4(1, 2, 3, 4),
-			Port: 80,
+			Port: 543543,
 			Zone: "",
 		},
 		RemoteAddr: &net.TCPAddr{
 			IP:   net.IPv4(4, 3, 2, 1),
-			Port: 111,
+			Port: 8080,
 			Zone: "",
 		},
 	})
@@ -53,8 +53,7 @@ func TestNewClientConnectionsStatsHandler(t *testing.T) {
 		# TYPE promgrpctest_client_connections gauge
 	`
 	expected := `
-		promgrpctest_client_connections{ grpc_local_addr = "1.2.3.4:80", grpc_remote_addr = "4.3.2.1" } 1
-		promgrpctest_client_connections{ grpc_local_addr = "1.2.3.4:90", grpc_remote_addr = "4.3.2.1" } 1
+		promgrpctest_client_connections{ grpc_local_addr = "1.2.3.4", grpc_remote_addr = "4.3.2.1:8080" } 2
 	`
 	if err := testutil.CollectAndCompare(h, strings.NewReader(metadata+expected), "promgrpctest_client_connections"); err != nil {
 		t.Fatal(err)

--- a/v4/options.go
+++ b/v4/options.go
@@ -14,6 +14,9 @@ type ShareableOption interface {
 }
 
 type statsHandlerOptions struct {
+	// stats.ConnTagInfo carries no information about whether it is an incoming or outgoing connection.
+	// Use IsClient method if available.
+	client           bool
 	handleRPCLabelFn HandleRPCLabelFunc
 	tagRPCLabelFn    TagRPCLabelFunc
 }

--- a/v4/stats_handler.go
+++ b/v4/stats_handler.go
@@ -135,11 +135,19 @@ func (h *baseStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) c
 
 // TagConn implements stats Handler interface.
 func (h *baseStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
-	remoteAddr, _, _ := net.SplitHostPort(info.RemoteAddr.String())
+	var remoteAddr, localAddr string
+
+	if h.options.client {
+		remoteAddr = info.RemoteAddr.String()
+		localAddr, _, _ = net.SplitHostPort(info.LocalAddr.String())
+	} else {
+		remoteAddr, _, _ = net.SplitHostPort(info.RemoteAddr.String())
+		localAddr = info.LocalAddr.String()
+	}
 
 	return context.WithValue(ctx, tagConnKey, connTagLabels{
 		remoteAddr:      remoteAddr,
-		localAddr:       info.LocalAddr.String(),
+		localAddr:       localAddr,
 		clientUserAgent: userAgentOnServerSide(ctx, &stats.RPCTagInfo{}),
 	})
 }


### PR DESCRIPTION
`baseStatsHandler.TagConn` is able to distinquish outgoing and incoming connections and trim appropriate address as a result metric `grpc_client_connections` is not anymore subject to cardinality explosion. Previous solution only affected `grpc_server_connections`. 